### PR TITLE
feat: adopt generic 15.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>15.3.2</version>
+        <version>15.4.0</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.cucumber</artifactId>

--- a/src/main/resources/layout/form.html
+++ b/src/main/resources/layout/form.html
@@ -1,4 +1,4 @@
-<div id="cucumber-edit-panel">
+<div id="cucumber-edit-panel" class="sbb-ui">
     <link rel='stylesheet' href='/polarion/cucumber/ui/css/petrel.css?bundle={BUNDLE}'>
     <link rel='stylesheet' href='/polarion/cucumber/ui/css/highlightjs.css?bundle={BUNDLE}'>
     <link rel='stylesheet' href='/polarion/cucumber/ui/generic/css/control-tokens.css?bundle={BUNDLE}'>


### PR DESCRIPTION
### Proposed changes

Bump generic to 15.4.0 (scope-only --sbb-* tokens) and wrap the feature editor panel in .sbb-ui so its Edit/Save/Cancel icons keep resolving the --sbb-*-icon tokens after generic dropped the global :root declarations.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
