### PR TITLE
chore: inherit swagger plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@
         <markdown2html-maven-plugin.user-guide.inputFile>${project.basedir}/USER_GUIDE.md</markdown2html-maven-plugin.user-guide.inputFile>
         <markdown2html-maven-plugin.user-guide.outputFileName>user-guide.html</markdown2html-maven-plugin.user-guide.outputFileName>
         <markdown2html-maven-plugin.user-guide.outputFile>${markdown2html-maven-plugin.extensionContextAdminHtml}/${markdown2html-maven-plugin.user-guide.outputFileName}</markdown2html-maven-plugin.user-guide.outputFile>
-        <swagger-maven-plugin.version>2.2.22</swagger-maven-plugin.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### Proposed changes

`swagger-maven-plugin-jakarta` is declared without a `<version>`, so it takes the one from the generic parent's `pluginManagement`. A local property of the same name overrode that value in the effective POM and pinned the build to **2.2.22** while the parent had long moved to **2.2.52** - and renovate never tracked it, because the property carries no version declaration of its own to attach an update to (it does not appear in this repo's Dependency Dashboard at all). Removing the property lets the version come from the parent, like everywhere else in the family.

The generated `docs/openapi.json` comes out **unchanged** - the two plugin versions produce the same specification.

Verified: full `mvn install` green.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
